### PR TITLE
Add MIT license and detailed README instructions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# crypto_wallet
+# Crypto Wallet
+
+O **Crypto Wallet** é um aplicativo Flutter voltado para consulta de cotações e
+acompanhamento do mercado de criptomoedas. Com ele é possível visualizar
+variações de preço, obter gráficos e organizar sua carteira de forma simples.
+
+## Objetivo
+
+Centralizar em um único aplicativo informações sobre diversas moedas
+digitais, permitindo que o usuário acompanhe o valor dos ativos de maneira
+rápida e intuitiva.
+
+## Como construir
+
+1. Instale as dependências do projeto:
+
+   ```bash
+   flutter pub get
+   ```
+
+2. Gere os recursos do *splash screen* (opcional):
+
+   ```bash
+   flutter pub run flutter_native_splash:create
+   ```
+
+3. Para compilar o aplicativo para Android ou iOS, utilize:
+
+   ```bash
+   flutter build apk   # ou flutter build ios
+   ```
+
+## Como executar
+
+Execute o aplicativo em um dispositivo físico ou emulador com o comando:
+
+```bash
+flutter run
+```
+
+O aplicativo será iniciado e você poderá navegar pelas telas de boas-vindas,
+lista de criptomoedas e compra de ativos.


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- expand `README.md` with project description and build/run instructions in Portuguese

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421cafac408322aee3c0acfd44f893